### PR TITLE
many changes for v0.5 release; see CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 0.5.0
+
+- Upgraded to Anaconda 2.2.0 from 2.0.1
+  - Includes support for Anaconda 2.1.0
+- Added support for [Miniconda](http://conda.pydata.org/miniconda.html)
+- Upgraded Vagrantfile:
+  - Upgraded Chef from 11.16+ to 12+ to match Kitchen tests
+  - Upgraded OS from 12.04 to 14.04
+
 ## 0.4.4
 
 Backwards-compatible fix for issue when using both the python cookbook and this

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ gem 'kitchen-vagrant'
 gem 'foodcritic'
 
 gem 'chef-rewind'
+
+gem 'nokogiri', '~> 1.5.0'

--- a/README.md
+++ b/README.md
@@ -37,22 +37,23 @@ of *0.1.0-1*). Again, YMMV.
 ## Quickstart
 
 The [Vagrantfile](Vagrantfile) is written to get you an Anaconda environment
-with minimal effort:
+with minimal effort (though it will take at least a few minutes to download the
+Anaconda installer itself):
 
 ```bash
 $> vagrant up --provision
 ...
 
 $> vagrant ssh
-$vagrant> export PATH=/opt/anaconda/2.0.1/bin:${PATH}
+$vagrant> export PATH=/opt/anaconda/2.2.0/bin:${PATH}
 $vagrant> conda --version
-conda 3.5.5
+conda 3.10.0
 
 # if you included `recipe[anaconda::shell_conveniences]` you don't have to do anything;
 # it's sourced in /etc/profile.d
 $> vagrant ssh
 $vagrant> conda --version
-conda 3.5.5
+conda 3.10.0
 ```
 
 In addition, by default an IPython notebook server is enabled and started:
@@ -81,7 +82,14 @@ The following are user-configurable attributes. Check
 [attributes/default.rb](attributes/default.rb) for default values.
 
 - `anaconda`
-  - `version`: the version to install
+  - `version`: the version to install. Valid values are:
+    - 1.8.0
+    - 1.9.2
+    - 2.0.1
+    - 2.1.0
+    - 2.2.0
+    - miniconda-python2
+    - miniconda-python3
   - `flavor`: either `x86` (32-bit) or `x86_64` (64-bit)
   - `install_root`: the parent directory of all anaconda installs. note that
     individual installs go into `#{install_root}/#{version}`
@@ -119,6 +127,8 @@ general, all it does is present the same options as `conda install`/`conda
 remove`.
 
 ### resource `anaconda_nbservice`
+
+**This only works with a full Anaconda installation! I.e. the notebook service will not work out-of-the-box if installed with miniconda**
 
 The `anaconda_nbservice` will run an IPython notebook server as a runit
 service:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,9 +3,8 @@
 
 Vagrant.configure('2') do |config|
   config.vm.hostname = 'anaconda-berkshelf'
+  # 14.04 LTS
   config.vm.box = 'ubuntu/trusty32'
-  #config.vm.box = 'precise32'
-  #config.vm.box_url = 'http://files.vagrantup.com/precise32.box'
   config.vm.network :private_network, ip: '33.33.33.123'
 
   # ssh
@@ -14,8 +13,16 @@ Vagrant.configure('2') do |config|
 
   # plugins
   config.berkshelf.enabled = true
-  #config.berkshelf.berksfile_path = ''
   config.omnibus.chef_version = :latest
+
+  # vm tweaks
+  config.vm.provider :virtualbox do |vb|
+    #vb.memory = 1024
+    #vb.cpus = 2
+    # "no matter how much CPU is used in the VM, no more than 50% would be used on your own host machine"
+    # http://docs.vagrantup.com/v2/virtualbox/configuration.html
+    #vb.customize [ 'modifyvm', :id, '--cpuexecutioncap', '50' ]
+  end
 
   # provisioning
 
@@ -28,6 +35,10 @@ Vagrant.configure('2') do |config|
     'Anaconda-1.9.2-Linux-x86_64.sh',
     'Anaconda-2.0.1-Linux-x86.sh',
     'Anaconda-2.0.1-Linux-x86_64.sh',
+    'Anaconda-2.1.0-Linux-x86.sh',
+    'Anaconda-2.1.0-Linux-x86_64.sh',
+    'Anaconda-2.2.0-Linux-x86.sh',
+    'Anaconda-2.2.0-Linux-x86_64.sh',
   ].each do |f|
     if File.exists?(f)
       config.vm.provision :shell do |shell|
@@ -40,7 +51,7 @@ Vagrant.configure('2') do |config|
   config.vm.provision :chef_solo do |chef|
     chef.json = {
       :anaconda => {
-        #:version => '2.0.1',
+        #:version => '2.2.0',
         #:flavor => 'x86',
         :accept_license => 'yes',
       }
@@ -53,5 +64,6 @@ Vagrant.configure('2') do |config|
     ]
 
     chef.custom_config_path = 'vagrant-solo.rb'
+    #chef.log_level = :debug
   end
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,18 +1,42 @@
-default.anaconda.version = '2.0.1'
+default.anaconda.version = '2.2.0'
 default.anaconda.flavor = 'x86'
 default.anaconda.installer = {
   '1.8.0' => {
+    'uri_prefix' => 'http://09c8d0b2229f813c1b93-c95ac804525aac4b6dba79b00b39d1d3.r79.cf1.rackcdn.com',
     'x86' => '9eeda2307e9f5c7927ce610fc9dcd632c3d42fab',
     'x86_64' => '44da25d5fec8a1acc26bad816c928e002d877334',
   },
   '1.9.2' => {
+    'uri_prefix' => 'http://09c8d0b2229f813c1b93-c95ac804525aac4b6dba79b00b39d1d3.r79.cf1.rackcdn.com',
     'x86' => '806a8edec3cde7d3e883fe6fda6999b643766e06',
     'x86_64' => '8b3d2800b555c28879f51373ea8ca32c3c79a424',
   },
   '2.0.1' => {
+    'uri_prefix' => 'http://09c8d0b2229f813c1b93-c95ac804525aac4b6dba79b00b39d1d3.r79.cf1.rackcdn.com',
     'x86' => '7384b070191967f205e7856e9c82396867e22601',
     'x86_64' => 'd5b0e4e3619bd75fedcb0dafa585886198ec7014',
   },
+  '2.1.0' => {
+    'uri_prefix' => 'http://09c8d0b2229f813c1b93-c95ac804525aac4b6dba79b00b39d1d3.r79.cf1.rackcdn.com',
+    'x86' => 'fd70c08719e6b5caae45b7c8402c6975a8cbc0e3e2a9c4c977554d1784f28b72',
+    'x86_64' => '191fbf290747614929d0bdd576e330c944b22a67585d1c185e0d2b3a3e65e1c0',
+  },
+  '2.2.0' => {
+    'uri_prefix' => 'https://3230d63b5fc54e62148e-c95ac804525aac4b6dba79b00b39d1d3.ssl.cf1.rackcdn.com',
+    'x86' => '6437d5b08a19c3501f2f5dc3ae1ae16f91adf6bed0f067ef0806a9911b1bef15',
+    'x86_64' => 'ca2582cb2188073b0f348ad42207211a2b85c10b244265b5b27bab04481b88a2',
+  },
+  'miniconda-python2' => {
+    'uri_prefix' => 'https://repo.continuum.io/miniconda',
+    # miniconda is always latest, so it doesn't have a stable checksum
+    'x86' => nil,
+    'x86_64' => nil,
+  },
+  'miniconda-python3' => {
+    'uri_prefix' => 'https://repo.continuum.io/miniconda',
+    'x86' => nil,
+    'x86_64' => nil,
+  }
 }
 
 # specific versions are installed _under_ this directory

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'matt.chu@gmail.com'
 license          'MIT'
 description      'Installs/Configures anaconda'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.5'
+version          '0.5.0'
 
 supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 13.04'

--- a/recipes/notebook_server.rb
+++ b/recipes/notebook_server.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: anaconda
 # Recipe:: notebook_server
 #
-# Copyright (C) 2014 Matt Chu
+# Copyright (C) 2015 Matt Chu
 #
 # All rights reserved - Do Not Redistribute
 #

--- a/recipes/package_tests.rb
+++ b/recipes/package_tests.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: anaconda
 # Recipe:: package_tests
 #
-# Copyright (C) 2014 Matt Chu
+# Copyright (C) 2015 Matt Chu
 #
 # All rights reserved - Do Not Redistribute
 #

--- a/recipes/python_workaround.rb
+++ b/recipes/python_workaround.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: anaconda
 # Recipe:: python_workaround
 #
-# Copyright (C) 2014 Matt Chu
+# Copyright (C) 2015 Matt Chu
 #
 # All rights reserved - Do Not Redistribute
 #

--- a/recipes/shell_conveniences.rb
+++ b/recipes/shell_conveniences.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: anaconda
 # Recipe:: shell-conveniences
 #
-# Copyright (C) 2014 Matt Chu
+# Copyright (C) 2015 Matt Chu
 #
 # All rights reserved - Do Not Redistribute
 #

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -82,10 +82,11 @@ shared_examples 'general tests' do |platform, platform_version|
     end
 
     it 'has a workaround for python: https://github.com/thmttch/chef-continuum-anaconda/issues/12' do
-      pending('How do you include a cookbook for testing purposes only?')
+      pending('How do you include a cookbook for testing purposes only? Needs python')
 
       chef_run.converge('python::default')
       chef_run.converge(described_recipe)
+      chef_run.converge('anaconda::python_workaround')
 
       # TODO test that python_pip[setuptools] is removed/disabled
     end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,18 +1,5 @@
 require 'serverspec'
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-
-RSpec.configure do |c|
-  c.before :all do
-    c.path = '/sbin:/usr/sbin'
-  end
-end
-
-describe 'general tests' do
-
-  it 'installs anaconda 2.0.1' do
-    command('/opt/anaconda/2.0.1/bin/conda --version').should return_stdout 'conda 3.5.5'
-  end
-
+describe command('/opt/anaconda/2.2.0/bin/conda --version') do
+  its(:stdout) { should match /conda 3.10.0/ }
 end


### PR DESCRIPTION
From CHANGELOG:

## 0.5.0

- Upgraded to Anaconda 2.2.0 from 2.0.1
  - Includes support for Anaconda 2.1.0
- Added support for [Miniconda](http://conda.pydata.org/miniconda.html)
- Upgraded Vagrantfile:
  - Upgraded Chef from 11.16+ to 12+ to match Kitchen tests
  - Upgraded OS from 12.04 to 14.04