### PR TITLE
Adding option to install Anaconda3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ bin/*
 
 # anaconda installs should not be checked in
 Anaconda-*-Linux-*.sh
+
+# OSX
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The following are user-configurable attributes. Check
     - 2.0.1
     - 2.1.0
     - 2.2.0
+    - 3-2.2.0 (uses Python 3.4)
     - miniconda-python2
     - miniconda-python3
   - `flavor`: either `x86` (32-bit) or `x86_64` (64-bit)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure('2') do |config|
   config.vm.hostname = 'anaconda-berkshelf'
   # 14.04 LTS
-  config.vm.box = 'ubuntu/trusty32'
+  config.vm.box = 'ubuntu/trusty64'
   config.vm.network :private_network, ip: '33.33.33.123'
 
   # ssh
@@ -39,6 +39,8 @@ Vagrant.configure('2') do |config|
     'Anaconda-2.1.0-Linux-x86_64.sh',
     'Anaconda-2.2.0-Linux-x86.sh',
     'Anaconda-2.2.0-Linux-x86_64.sh',
+    'Anaconda3-2.2.0-Linux-x86.sh',
+    'Anaconda3-2.2.0-Linux-x86_64.sh',
   ].each do |f|
     if File.exists?(f)
       config.vm.provision :shell do |shell|
@@ -51,8 +53,8 @@ Vagrant.configure('2') do |config|
   config.vm.provision :chef_solo do |chef|
     chef.json = {
       :anaconda => {
-        #:version => '2.2.0',
-        #:flavor => 'x86',
+        :version => '3-2.2.0',
+        :flavor => 'x86_64',
         :accept_license => 'yes',
       }
     }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,11 @@ default.anaconda.installer = {
     'x86' => '6437d5b08a19c3501f2f5dc3ae1ae16f91adf6bed0f067ef0806a9911b1bef15',
     'x86_64' => 'ca2582cb2188073b0f348ad42207211a2b85c10b244265b5b27bab04481b88a2',
   },
+  '3-2.2.0' => {
+    'uri_prefix' => 'https://3230d63b5fc54e62148e-c95ac804525aac4b6dba79b00b39d1d3.ssl.cf1.rackcdn.com',
+    'x86' => '223655cd256aa912dfc83ab24570e47bb3808bc3b0c6bd21b5db0fcf2750883e',
+    'x86_64' => '4aac68743e7706adb93f042f970373a6e7e087dbf4b02ac467c94ca4ce33d2d1',
+  },
   'miniconda-python2' => {
     'uri_prefix' => 'https://repo.continuum.io/miniconda',
     # miniconda is always latest, so it doesn't have a stable checksum

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,8 @@ installer =
     "Miniconda-latest-Linux-#{flavor}.sh"
   elsif 'miniconda-python3' == version
     "Miniconda3-latest-Linux-#{flavor}.sh"
+  elsif '3-2.2.0' == version
+    "Anaconda3-2.2.0-Linux-#{flavor}.sh"
   else
     "Anaconda-#{version}-Linux-#{flavor}.sh"
   end


### PR DESCRIPTION
Hi,

I just wanted to add the ability to install the version of Anaconda that runs Python 3.4 by default. In the process, I also need to include .DS_store in the .gitignore.

Cheers,
Nathaniel