### PR TITLE
post 0.7 release fixes and cleanup; from CHANGELOG:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Berksfile.lock
 \#*#
 .*.sw[a-z]
 *.un~
+/cookbook
 /cookbooks
 
 # Bundler
@@ -20,6 +21,9 @@ bin/*
 
 # local anaconda installers should not be checked in
 Anaconda*-*-Linux-*.sh
+
+# no logfiles
+*.log
 
 # OSX
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## 0.7.1
+
+**This cookbook is now up for adoption! See CONTRIBUTING.md for details.**
+
+- Post release cleanup:
+  - release script and better document release process
+  - remove references to Chef DK
+- (WIP!) Update Vagrant instructions:
+  - Use Vagrant 2.0
+  - Update image to use Ubuntu 16.04 LTS (xenial), from 14.04 LTS
+- Lint/Quality
+  - Added CONTRIBUTING.md
+  - Added TESTING.md, and move content from README.md to that file
+  - Remove vim swapfiles from release, because chefignore doesn't seem to do
+    shit.
+- Added checksums for new 5.0 Anaconda installers
+
 ## 0.7.0
 
 Many, many changes and fixes to support both the latest Chef version and the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+This cookbook is now up for adoption! Open an issue, or contact me in some way,
+if you have any interest in taking over maintenance or development of this
+cookbook.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # anaconda cookbook
 
+**This cookbook is now up for adoption! See CONTRIBUTING.md for details.**
+
 Chef cookbook for installing [Continuum Analytic](http://continuum.io/)'s
 [Anaconda](https://store.continuum.io/cshop/anaconda/): "completely free Python
 distribution for large-scale data processing, predictive analytics, and
@@ -12,46 +14,42 @@ scientific computing". Specifically:
   - python2 or python3
   - x86 or x86_64
 - Usage tested on Ubuntu, unittested on Debian, CentOS, and RedHat. See [rspec
-  tests](spec/default_spec.rb#L100) and [kitchen tests](.kitchen.yml#L16) for
+  tests](spec/default_spec.rb#L101) and [kitchen tests](.kitchen.yml#L18) for
   the full list.
 
 This also serves as an example for developing and testing Chef cookbooks. It
 uses:
 
-- [ChefDK](https://downloads.chef.io/chef-dk/); 0.8.1
-  - chef-client 12.4.4
-  - [Berkshelf](http://berkshelf.com) for dependency resolution; 3.3.0
+- ~[ChefDK](https://downloads.chef.io/chef-dk/)~ Given up on this for
+  now; uses standard RVM and Gemfile to manage installation
+  - chef-client 13.6
+  - [Berkshelf](http://berkshelf.com) for dependency resolution; 6.3
   - [Test Kitchen](https://github.com/test-kitchen/test-kitchen) for
     comprehensive testing across multiple platforms, with tests written in
-    [serverspec](http://serverspec.org); 1.4.2
+    [serverspec](http://serverspec.org); 1.19
     - Docker, with
       [kitchen-docker](https://github.com/portertech/kitchen-docker)
       integration
-  - [Foodcritic](http://acrmp.github.io/foodcritic/) for style checking; 5.0.0
-- RSpec/[Chefspec](https://github.com/sethvargo/chefspec) for rapid testing;
-  3.3.2
-
-**Note that the release process uses Chef 11 because of <https://github.com/chef/chef/issues/3888>**
+  - [Foodcritic](http://acrmp.github.io/foodcritic/) for style checking; 12.2
+- RSpec (3.7)/[Chefspec](https://github.com/sethvargo/chefspec) (7.1) for unit testing
 
 In addition:
 
 - [Vagrant](https://www.vagrantup.com) to provide an out-of-the-box working
-  example; 1.7.4
+  example; only tested with 2.0.
 
 ## Requirements
 
 If you want to just have a working Anaconda VM, install:
 
 - Vagrant
+  - [vagrant-triggers](https://github.com/emyl/vagrant-triggers)
 
 For the full experience (e.g. running the test suite), also install:
 
-- ChefDK
-  - [vagrant-omnibus](https://github.com/schisamo/vagrant-omnibus)
-  - [vagrant-berkshelf](https://github.com/berkshelf/vagrant-berkshelf)
+- [vagrant-omnibus](https://github.com/schisamo/vagrant-omnibus)
+- [vagrant-berkshelf](https://github.com/berkshelf/vagrant-berkshelf)
 - Docker
-  - Don't forget [Docker Machine](https://docs.docker.com/machine/) if you're
-    on OSX; installing this via homebrew is highly recommended.
 
 ## Quickstart
 
@@ -188,48 +186,9 @@ your own run service template:
   end
   ```
 
-## Developer setup and config
+## Developer setup, config, and tests
 
-install chef-dk; i installed using homebrew: https://github.com/chef/chef-dk
-
-eval "$(chef shell-init bash)" && script/cibuild
-
-### Tests
-
-To run the full test suite:
-
-  ```bash
-  # this will take a while, especially the first time
-  $> script/cibuild
-  ...
-
-  # check the final result; bash return codes: 0 is good, anything else is not
-  $> echo $?
-  ```
-
-- to run just the [chefspecs](spec/default_spec.rb):
-
-  ```bash
-  $> rspec
-  ```
-
-- to run just the test kitchen serverspec [integration
-  tests](test/integration/default/serverspec/default_spec.rb):
-
-  ```bash
-  # this is done via docker/kitchen-docker
-  # the list of OSes is defined in .kitchen.yml
-  $> kitchen verify
-
-  # test a specific OS; `kitchen list`
-  $> kitchen verify default-ubuntu-1204
-  ```
-
-- check for style issues with Foodcritic
-
-  ```bash
-  $> foodcritic
-  ```
+See [TESTING.md](TESTING.md) for details.
 
 ## Releases and issues
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,44 @@
+# anaconda cookbook: Testing
+
+## Developer setup and config
+
+You can try [installing Chef DK](https://docs.chef.io/install_dk.html), but
+I've found it much easier to just use RVM and Bundler to manage ruby and gems;
+YMMV.
+
+### Tests
+
+To run the full test suite:
+
+  ```bash
+  # this will take a while, especially the first time
+  $> script/cibuild
+  ...
+
+  # check the final result; bash return codes: 0 is good, anything else is not
+  $> echo $?
+  ```
+
+- to run just the [chefspecs](spec/default_spec.rb):
+
+  ```bash
+  $> rspec
+  ```
+
+- to run just the test kitchen serverspec [integration
+  tests](test/integration/default/serverspec/default_spec.rb):
+
+  ```bash
+  # this is done via docker/kitchen-docker
+  # the list of OSes is defined in .kitchen.yml
+  $> kitchen verify
+
+  # test a specific OS; `kitchen list`
+  $> kitchen verify default-ubuntu-1604
+  ```
+
+- check for style issues with Foodcritic
+
+  ```bash
+  $> foodcritic
+  ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 Vagrant.configure('2') do |config|
   config.vm.hostname = 'anaconda-berkshelf'
-  # 14.04 LTS
-  config.vm.box = 'ubuntu/trusty64'
+  # 16.04 LTS
+  config.vm.box = 'ubuntu/xenial64'
   config.vm.network :private_network, ip: '33.33.33.123'
 
   # ssh
@@ -16,7 +16,8 @@ Vagrant.configure('2') do |config|
   config.vm.provider :virtualbox do |vb|
     #vb.memory = 1024
     #vb.cpus = 2
-    # "no matter how much CPU is used in the VM, no more than 50% would be used on your own host machine"
+    # "no matter how much CPU is used in the VM, no more than 50% would be used
+    # on your own host machine"
     # http://docs.vagrantup.com/v2/virtualbox/configuration.html
     #vb.customize [ 'modifyvm', :id, '--cpuexecutioncap', '50' ]
   end
@@ -29,14 +30,16 @@ Vagrant.configure('2') do |config|
     run_remote <<-SCRIPT
     VAGRANT_MOUNT=/vagrant/docker/container/installers
 
-    for f in $(ls ${VAGRANT_MOUNT}); do
-      echo "checking for ${f} in cache"
-      if [[ ! -f /var/chef/cache/${f} ]]; then
-        cp -v ${VAGRANT_MOUNT}/${f} /var/chef/cache
-      else
-        echo "${f} already in cache"
-      fi
-    done
+    if [[ -d ${VAGRANT_MOUNT} ]]; then
+      for f in $(ls ${VAGRANT_MOUNT}); do
+        echo "checking for ${f} in cache"
+        if [[ ! -f /var/chef/cache/${f} ]]; then
+          cp -v ${VAGRANT_MOUNT}/${f} /var/chef/cache
+        else
+          echo "${f} already in cache"
+        fi
+      done
+    fi
     SCRIPT
   end
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,13 +50,13 @@ default['anaconda']['installer_info'] = {
     '5.0.1' => {
       'python2' => {
         'uri_prefix' => 'https://repo.continuum.io/archive',
-        'x86' => nil,
-        'x86_64' => nil,
+        'x86' => '88c8d698fff16af15862daca10e94a0a46380dcffda45f8d89f5fe03f6bd2528',
+        'x86_64' => '23c676510bc87c95184ecaeb327c0b2c88007278e0d698622e2dd8fb14d9faa4',
       },
       'python3' => {
         'uri_prefix' => 'https://repo.continuum.io/archive',
-        'x86' => nil,
-        'x86_64' => nil,
+        'x86' => '991a4b656fcb0236864fbb27ff03bb7f3d98579205829b76b66f65cfa6734240',
+        'x86_64' => '55e4db1919f49c92d5abbf27a4be5986ae157f074bf9f8238963cd4582a4068a',
       },
     },
   },

--- a/script/release-config.rb
+++ b/script/release-config.rb
@@ -1,0 +1,8 @@
+log_level               :info
+log_location            STDOUT
+
+# apparently, this should be the username used to log into https://supermarket.chef.io
+# https://blog.chef.io/2015/03/16/using-chef-supermarket-a-guided-tour/
+node_name               'thmttch'
+# this might not work with a relative path, and obviously is not checked in!
+client_key              'script/release-key.pem'

--- a/script/release-to-supermarket.sh
+++ b/script/release-to-supermarket.sh
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 
-echo "Don't know how to automate this (creds), so here are the instructions:"
-echo ""
+cat <<-INSTRUCTIONS
+Prep for release:
 
-echo "cut a github release, checkout that tag locally"
-echo ""
+1. Cut a github release
+2. Locally checkout the release tag
+3. If not available, log into Supermarket and generate a new key via Manage
+   Profile. Update release-config.rb accordingly.
 
-echo "use berkshelf to vendor a clean version of the cookbook, and update to supermarket"
-echo ""
-echo "berks vendor cookbooks"
-echo 'knife cookbook site share anaconda "Programming Languages" --cookbook-path cookbooks --config ${CHEF_PUB}'
-echo ""
-echo "https://docs.getchef.com/knife_cookbook_site.html#share"
+Upload to supermarket:
 
-echo "BUMP METADATA.RB for next release! master is development"
-echo ""
+# Use berkshelf to vendor a clean version of the cookbook; REMOVE ALL VIM
+# SWAPFILES! chefignore doesn't seem to do shit.
+$> find . -name *.swp | xargs -I[] rm -vf []
+$> berks vendor cookbooks
+# Upload to supermarket
+$> knife cookbook site share anaconda "Programming Languages" --cookbook-path cookbooks --supermarket-site https://supermarket.chef.io --config script/release-config.rb
 
-echo "https://supermarket.chef.io/cookbooks/anaconda"
+Post-release:
 
-echo "ffs chef 12 supermarket release doesn't work; use chefdk = 0.3.6"
+1. Bump metadata.rb version for next release! master is development
+INSTRUCTIONS


### PR DESCRIPTION
**This cookbook is now up for adoption! See CONTRIBUTING.md for details.**

- Post release cleanup:
  - release script and better document release process
  - remove references to Chef DK
- (WIP!) Update Vagrant instructions:
  - Use Vagrant 2.0
  - Update image to use Ubuntu 16.04 LTS (xenial), from 14.04 LTS
- Lint/Quality
  - Added CONTRIBUTING.md
  - Added TESTING.md, and move content from README.md to that file
  - Remove vim swapfiles from release, because chefignore doesn't seem to do
    shit.
- Added checksums for new 5.0 Anaconda installers