### PR TITLE
0.7.2: notebook fixes, miscellaneous cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # CHANGELOG
 
+## 0.7.2
+
+**This is a backwards-INCOMPATIBLE release**
+
+- Catch up with ipython -> jupyter rebranding: renamed everything to juptyer.
+  This includes directories, attributes, and other backwards-incompatible
+  changes.
+- More fixes to release process: don't include unnecessary files during berkshelf
+  vendoring and release
+- Vagrant and notebook server fixes
+  - you can use attributes to set the notebook server's security token. _Be
+    careful with this config!_ It is disabled in the quickstart Vagrant setup
+    for convenience, and remains _enabled by default_.
+- Foodcritic fixes; resolves:
+  - FC017: LWRP does not notify when updated: anaconda/providers/nbservice.rb:21
+  - FC017: LWRP does not notify when updated: anaconda/providers/package.rb:21
+  - FC017: LWRP does not notify when updated: anaconda/providers/package.rb:58
+  - FC059: LWRP provider does not declare use_inline_resources: anaconda/providers/nbservice.rb:1
+  - FC059: LWRP provider does not declare use_inline_resources: anaconda/providers/package.rb:1
+  - FC048: Prefer Mixlib::ShellOut: ./providers/nbservice.rb:12
+  - FC048: Prefer Mixlib::ShellOut: ./providers/package.rb:12
+
 ## 0.7.1
 
 **This cookbook is now up for adoption! See CONTRIBUTING.md for details.**

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ installer itself.
   conda 4.3.30
   ```
 
-It includes a Jupyter (IPython) notebook server accessible at <http://33.33.33.123:8888>
+It includes a Jupyter notebook server accessible at
+<http://33.33.33.123:8888>. **Token authentication is disabled in the
+quickstart Vagrant setup.**
 
 Lastly, to use it in a cookbook:
 
@@ -158,7 +160,7 @@ The `anaconda_nbservice` will run a Jupyter notebook server as a runit service:
     ip '*'
     port '8888'
 
-    install_dir '/opt/ipython/server'
+    install_dir '/opt/jupyter/server'
 
     service_action [ :enable, :start ]
   end
@@ -169,8 +171,8 @@ your own run service template:
 
   ```ruby
   anaconda_nbservice 'server-with-custom-template' do
-    user ipython_user
-    group ipython_group
+    user jupyter_user
+    group jupyter_group
 
     install_dir install_dir
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -40,5 +40,6 @@ To run the full test suite:
 - check for style issues with Foodcritic
 
   ```bash
-  $> foodcritic
+  # run on the project root dir
+  $> foodcritic .
   ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,9 @@ Vagrant.configure('2') do |config|
 
   # dev optimization: anaconda installers are big, so put it in the guest's
   # chef cache if it's available on the host
+  #
+  # TODO: need to increase the virtualbox disk space for the installers, eg
+  # https://unix.stackexchange.com/questions/176687/set-storage-size-on-creation-of-vm-virtualbox
   config.trigger.before :provision, :stdout => true do
     run_remote <<-SCRIPT
     VAGRANT_MOUNT=/vagrant/docker/container/installers
@@ -45,8 +48,14 @@ Vagrant.configure('2') do |config|
 
   config.vm.provision :chef_solo do |chef|
     chef.json = {
-      :anaconda => {
-        :accept_license => 'yes',
+      'anaconda' => {
+        'accept_license' => 'yes',
+        'notebook' => {
+          # set an empty security token, which effectively disables this
+          # security feature; this is for the quickstart Vagrant image ONLY!
+          'use_provided_token' => true,
+          'token' => '',
+        }
       }
     }
 
@@ -58,6 +67,7 @@ Vagrant.configure('2') do |config|
 
     chef.custom_config_path = 'vagrant-solo.rb'
     #chef.log_level = :debug
+    #chef.verbose_logging = true
   end
 end
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,5 +92,9 @@ default['anaconda']['notebook'] = {
   'port' => 8888,
   'owner' => node['anaconda']['owner'],
   'group' => node['anaconda']['group'],
-  'install_dir' => '/opt/ipython/server',
+  'install_dir' => '/opt/jupyter/server',
+  # the default is to NOT set the security token, to ensure that a secure key
+  # is chosen and set
+  'use_provided_token' => false,
+  'token' => '',
 }

--- a/chefignore
+++ b/chefignore
@@ -53,6 +53,7 @@ test/*
 features/*
 Guardfile
 Procfile
+*.log
 
 # SCM #
 #######
@@ -76,8 +77,8 @@ tmp
 
 # Cookbooks #
 #############
-CONTRIBUTING
-CHANGELOG*
+#CONTRIBUTING
+#CHANGELOG*
 
 # Strainer #
 ############
@@ -89,6 +90,7 @@ Strainerfile
 # Vagrant #
 ###########
 .vagrant
+vagrant-solo.rb
 Vagrantfile
 
 # Travis #
@@ -97,3 +99,5 @@ Vagrantfile
 
 # local anaconda installers should not be part of the cookbook
 Anaconda*-*-Linux-*.sh
+# install scripts don't need to be in the cookbook
+script

--- a/providers/nbservice.rb
+++ b/providers/nbservice.rb
@@ -1,13 +1,15 @@
+use_inline_resources
+
 def whyrun_supported?
   true
 end
 
-def cmd_ipython
-  "#{node['anaconda']['install_root']}/#{node['anaconda']['version']}/bin/ipython"
+def cmd_jupyter
+  "#{node['anaconda']['install_root']}/#{node['anaconda']['version']}/bin/jupyter"
 end
 
 def is_installed?(package_name)
-  `"#{cmd_conda}" list`.include?(package_name)
+  Mixlib::ShellOut.new("#{cmd_conda} list").run_command.stdout.include?(package_name)
 end
 
 def log_opts(node)
@@ -26,6 +28,8 @@ action :create do
   owner = r.owner || node['anaconda']['notebook']['owner']
   group = r.group || node['anaconda']['notebook']['group']
   install_dir = r.install_dir || node['anaconda']['notebook']['install_dir']
+  use_provided_token = r.use_provided_token || node['anaconda']['notebook']['use_provided_token']
+  token = r.token || node['anaconda']['notebook']['token']
 
   directory install_dir do
     owner owner
@@ -33,8 +37,8 @@ action :create do
     recursive true
   end
 
-  ipython_dir = "#{install_dir}/.ipython"
-  directory ipython_dir do
+  jupyter_dir = "#{install_dir}/.juptyer"
+  directory jupyter_dir do
     owner owner
     group group
     recursive true
@@ -46,20 +50,22 @@ action :create do
   service_action = r.service_action || [ :enable, :start ]
 
   template_cookbook = r.template_cookbook || 'anaconda'
-  run_template_name = r.run_template_name || 'ipython-notebook'
+  run_template_name = r.run_template_name || 'jupyter-notebook'
   run_template_opts = r.run_template_opts || {
     :owner => owner,
-    :cmd_ipython => cmd_ipython(),
+    :cmd_jupyter => cmd_jupyter(),
     :notebook_dir => install_dir,
-    :ipython_dir => ipython_dir,
+    :jupyter_dir => jupyter_dir,
     :ip => ip,
     :port => port,
+    :use_provided_token => use_provided_token,
+    :token => token,
     :pythonpath => pythonpath,
     :pythonstartup => pythonstartup,
     :files_to_source => files_to_source,
   }
 
-  runit_service "ipython-notebook-#{r.name}" do
+  runit_service "jupyter-notebook-#{r.name}" do
     options(run_template_opts)
     default_logger true
     run_template_name run_template_name

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -1,3 +1,5 @@
+use_inline_resources
+
 def whyrun_supported?
   true
 end
@@ -7,7 +9,7 @@ def cmd_conda
 end
 
 def is_installed?(package_name)
-  `"#{cmd_conda}" list`.include?(package_name)
+  Mixlib::ShellOut.new("#{cmd_conda} list").run_command.stdout.include?(package_name)
 end
 
 def log_opts(node)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,8 @@ include_recipe 'tar::default'
 group node['anaconda']['group']
 user node['anaconda']['owner'] do
   gid node['anaconda']['group']
+  home node['anaconda']['home']
+  manage_home true
 end
 
 version = node['anaconda']['version']

--- a/recipes/notebook_server.rb
+++ b/recipes/notebook_server.rb
@@ -18,5 +18,7 @@ anaconda_nbservice 'notebook-server' do
 
   install_dir node['anaconda']['notebook']['install_dir']
 
+  token node['anaconda']['notebook']['token']
+
   service_action [ :enable, :start ]
 end

--- a/resources/nbservice.rb
+++ b/resources/nbservice.rb
@@ -13,6 +13,9 @@ attribute :group, :kind_of => String
 
 attribute :install_dir, :kind_of => String
 
+attribute :use_provided_token, :kind_of => [TrueClass, FalseClass]
+attribute :token, :kind_of => String
+
 # if you really need it
 attribute :pythonpath, :kind_of => Array
 attribute :pythonstartup, :kind_of => String

--- a/script/release-config.rb
+++ b/script/release-config.rb
@@ -5,4 +5,4 @@ log_location            STDOUT
 # https://blog.chef.io/2015/03/16/using-chef-supermarket-a-guided-tour/
 node_name               'thmttch'
 # this might not work with a relative path, and obviously is not checked in!
-client_key              'script/release-key.pem'
+client_key              '~/.ssh/chef-supermarket-release-key.pem'

--- a/templates/default/sv-jupyter-notebook-run.erb
+++ b/templates/default/sv-jupyter-notebook-run.erb
@@ -18,8 +18,8 @@ pushd <%= @options[:notebook_dir] %>
 exec 2>&1
 exec \
   <%= "chpst -u #{@options[:owner]}" if @options[:owner] %> \
-    <%= @options[:cmd_ipython] %> notebook \
-      --ipython-dir=<%= @options[:ipython_dir] %> \
+    <%= @options[:cmd_jupyter] %> notebook \
       --ip=<%= @options[:ip] %> \
       --port=<%= @options[:port] %> \
+      <%= "--NotebookApp.token='#{@options[:token]}'" if @options[:use_provided_token] %> \
       --no-browser


### PR DESCRIPTION
**This will be a backwards-INCOMPATIBLE release**:

- Catch up with ipython -> jupyter rebranding: renamed everything to juptyer
- More fixes to release process: don't include unnecessary files during berkshelf
  vendoring and release
- Vagrant and notebook server fixes
  - you can use attributes to set the notebook server's security token. _Be
    careful with this config!_ It is disabled in the quickstart Vagrant setup
    for convenience, and remains _enabled by default_.
- Foodcritic fixes; resolves:
  - FC017: LWRP does not notify when updated: anaconda/providers/nbservice.rb:21
  - FC017: LWRP does not notify when updated: anaconda/providers/package.rb:21
  - FC017: LWRP does not notify when updated: anaconda/providers/package.rb:58
  - FC059: LWRP provider does not declare use_inline_resources: anaconda/providers/nbservice.rb:1
  - FC059: LWRP provider does not declare use_inline_resources: anaconda/providers/package.rb:1
  - FC048: Prefer Mixlib::ShellOut: ./providers/nbservice.rb:12
  - FC048: Prefer Mixlib::ShellOut: ./providers/package.rb:12